### PR TITLE
[pt-br] Translation of the State of Rust Survey FAQ

### DIFF
--- a/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
+++ b/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
@@ -1,6 +1,6 @@
 # Perguntas Frequentes sobre o Censo sobre a linguagem Rust (FAQ)
 
-Nesse FAQ tentaremos responder perguntas comuns sobre o Censo Comunitário Anual sobre o estado da linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não hexite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
+Nesse FAQ tentaremos responder perguntas comuns sobre o Censo Comunitário Anual sobre o estado da linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não hesite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
 
 [O documento original em Ingles se encontra aqui](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ)
 

--- a/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
+++ b/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
@@ -1,6 +1,6 @@
 # Perguntas Frequentes sobre o Censo sobre a linguagem Rust (FAQ)
 
-Nesse FAQ tentaremos responder perguntas comuns sobre o Censo Comunitário Anual sobre o estado da linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não exite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
+Nesse FAQ tentaremos responder perguntas comuns sobre o Censo Comunitário Anual sobre o estado da linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não hexite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
 
 [O documento original em Ingles se encontra aqui](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ)
 

--- a/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
+++ b/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
@@ -29,7 +29,7 @@ As respostas da pesquisa serão anonimizadas, agregadas e sumarizadas. Uma anali
 
 ### Como serão tratadas as informações de identificação pessoal (PII)?
 
-Quase todas as perguntas da pesquisa são opcionais. Você está convidado a compartilhar a maior ou menor quantidade de informação que você se sentir confortável em nos contar.
+Quase todas as perguntas da pesquisa são opcionais. Você está convidado a compartilhar o tanto de informação que você se sentir confortável em nos contar.
 Apenas a Equipe Core e os líderes da pesquisa da Equipe de Comunidade terão acesso aos dados brutos da pesquisa. Todas as respostas serão anonimizadas antes de serem compartilhadas com as outras equipes e antes da publicação dos resultados.
 
 ### Qual o motivo de coletar dados de contato na pesquisa?

--- a/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
+++ b/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
@@ -1,6 +1,6 @@
 # Perguntas Frequentes sobre a Pesquisa Sobre a Comunidade da Linguagem Rust (FAQ)
 
-Nesse FAQ tentaremos responder perguntas comuns sobre a pesquisa anual aobre a Comunidade da Linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não hesite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
+Nesse FAQ tentaremos responder perguntas comuns sobre a pesquisa anual sobre a Comunidade da Linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não hesite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
 
 [O documento original em Inglês se encontra aqui](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ)
 
@@ -25,7 +25,7 @@ A pesquisa inclui algumas perguntas básicas sobre o uso de Rust, suas opiniões
 
 ## Como serão usados os dados das respostas?
 
-As respostas da pesquisa serão anonimizadas, agregadas e resumidas. Uma analise geral sera publicada em https://blog.rust-lang.org
+As respostas da pesquisa serão anonimizadas, agrupadas e resumidas. Uma analise geral sera publicada em https://blog.rust-lang.org
 
 ### Como serão tratadas as informações de identificação pessoal (PII)?
 
@@ -46,7 +46,7 @@ Caso você queira ser contactado por qualquer um desses motivos, ou qualquer  ou
 
 ## Onde e quando serão publicado os resultados?
 
-Esperamos publicar os resultados sumarizados dentro de um ou dois meses depois que a pesquisa estiver completa. Os resultados serão publicados no [blog oficial do projeto](https://blog.rust-lang.org).
+Esperamos publicar os resultados resumidos dentro de um ou dois meses depois que a pesquisa estiver completa. Os resultados serão publicados no [blog oficial do projeto](https://blog.rust-lang.org).
 
 ## Onde eu posso ver os resultados anteriores?
 

--- a/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
+++ b/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
@@ -1,19 +1,19 @@
-# Perguntas Frequentes sobre o Censo sobre a linguagem Rust (FAQ)
+# Perguntas Frequentes sobre a Pesquisa Sobre a Comunidade da Linguagem Rust (FAQ)
 
-Nesse FAQ tentaremos responder perguntas comuns sobre o Censo Comunitário Anual sobre o estado da linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não hesite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
+Nesse FAQ tentaremos responder perguntas comuns sobre a pesquisa anual aobre a Comunidade da Linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não hesite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
 
-[O documento original em Ingles se encontra aqui](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ)
+[O documento original em Inglês se encontra aqui](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ)
 
 ## Por que essa pesquisa é importante para o projeto Rust?
 
-[Rust](https://rust-lang.org) é um projeto Open Source. Isso significa que queremos ouvir das pessoas de dentro e de fora do nosso ecossistema, sobre a linguagem, como ela é percebida, e como podemos tornar a linguagem mais acessível e nossa comunidade mais convidativa. Esse feedback dará para a comunidade a oportunidade de moldar o futuro do projeto. Queremos focar nos requerimentos dos usuários atuais e futuros usuários, para oferecer uma ferramenta conveniente para que sejam resolvidos problemas reais de uma maneira segura, eficiente e moderna.
+[Rust](https://rust-lang.org) é um projeto Open Source. Isso significa que queremos ouvir das pessoas de dentro e de fora do nosso ecossistema, sobre a linguagem, como ela é percebida, e como podemos tornar a linguagem mais acessível e nossa comunidade mais convidativa. Esse feedback dará para a comunidade a oportunidade de moldar o futuro do projeto. Queremos focar nos requerimentos dos usuários atuais e futuros, para oferecer uma ferramenta conveniente para que sejam resolvidos problemas reais de maneira segura, eficiente e moderna.
 
 ## Quais os objetivos da pesquisa?
 
 * Entender as principais prioridades de desenvolvimento e necessidades da comunidade
 * Categorizar a população de usuários da linguagem
 * Focar nossos esforços em eventos e conferências para gerar mais impacto
-* Identificar novas pessoas que queiram contribuir com os objetivos comunitários
+* Identificar novas pessoas que possam contribuir com os objetivos comunitários
 
 ## Quanto tempo demora para responder a pesquisa?
 
@@ -25,7 +25,7 @@ A pesquisa inclui algumas perguntas básicas sobre o uso de Rust, suas opiniões
 
 ## Como serão usados os dados das respostas?
 
-As respostas da pesquisa serão anonimizadas, agregadas e sumarizadas. Uma analise geral sera publicada em https://blog.rust-lang.org
+As respostas da pesquisa serão anonimizadas, agregadas e resumidas. Uma analise geral sera publicada em https://blog.rust-lang.org
 
 ### Como serão tratadas as informações de identificação pessoal (PII)?
 

--- a/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
+++ b/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md
@@ -1,0 +1,53 @@
+# Perguntas Frequentes sobre o Censo sobre a linguagem Rust (FAQ)
+
+Nesse FAQ tentaremos responder perguntas comuns sobre o Censo Comunitário Anual sobre o estado da linguagem Rust. Se você achar que existe uma pergunta faltando ou se você tiver alguma preocupação sobre este documento, não exite em contatar a [Equipe de Comunidade Rust](email to:community-team@rust-lang.org) ou abrir uma [issue para a Equipe de Comunidade](https://github.com/rust-community/team/issues).
+
+[O documento original em Ingles se encontra aqui](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ)
+
+## Por que essa pesquisa é importante para o projeto Rust?
+
+[Rust](https://rust-lang.org) é um projeto Open Source. Isso significa que queremos ouvir das pessoas de dentro e de fora do nosso ecossistema, sobre a linguagem, como ela é percebida, e como podemos tornar a linguagem mais acessível e nossa comunidade mais convidativa. Esse feedback dará para a comunidade a oportunidade de moldar o futuro do projeto. Queremos focar nos requerimentos dos usuários atuais e futuros usuários, para oferecer uma ferramenta conveniente para que sejam resolvidos problemas reais de uma maneira segura, eficiente e moderna.
+
+## Quais os objetivos da pesquisa?
+
+* Entender as principais prioridades de desenvolvimento e necessidades da comunidade
+* Categorizar a população de usuários da linguagem
+* Focar nossos esforços em eventos e conferências para gerar mais impacto
+* Identificar novas pessoas que queiram contribuir com os objetivos comunitários
+
+## Quanto tempo demora para responder a pesquisa?
+
+Em média, deve demorar de 10 a 15 minutos.
+
+## Quais tipos de perguntas estão presentes na pesquisa?
+
+A pesquisa inclui algumas perguntas básicas sobre o uso de Rust, suas opiniões sobre as ferramentas do ecossistema e suas bibliotecas, algumas perguntas básicas sobre a organização em que você trabalha e as intenções desse grupo em adotar Rust, histórico técnico, demografia e alguns feedbacks relacionados às atividades voltadas para a comunidade Rust.
+
+## Como serão usados os dados das respostas?
+
+As respostas da pesquisa serão anonimizadas, agregadas e sumarizadas. Uma analise geral sera publicada em https://blog.rust-lang.org
+
+### Como serão tratadas as informações de identificação pessoal (PII)?
+
+Quase todas as perguntas da pesquisa são opcionais. Você está convidado a compartilhar a maior ou menor quantidade de informação que você se sentir confortável em nos contar.
+Apenas a Equipe Core e os líderes da pesquisa da Equipe de Comunidade terão acesso aos dados brutos da pesquisa. Todas as respostas serão anonimizadas antes de serem compartilhadas com as outras equipes e antes da publicação dos resultados.
+
+### Qual o motivo de coletar dados de contato na pesquisa?
+
+A pesquisa oferece a opção de coletar dados de contato para os seguintes casos, caso você tenha interesse em:
+
+* futuras conferências ou encontros na sua área
+* ajudar a organizar um evento, encounter e/ou conferência sobre Rust
+* falar com a equipe Rust sobre a adoção de Rust na sua empresa
+* treinamentos sobre Rust
+* ser contactado por uma pessoa membra da equipe Rust sobre suas respostas na pesquisa
+
+Caso você queira ser contactado por qualquer um desses motivos, ou qualquer  outra preocupação, mas não quer associar seu email a suas respostas, você pode enviar um email para a [Equipe de Comunidade](mailto:community-team@rust-lang.org) ou para a [Equipe Core](mailto:core-team@rust-lang.org), e nós iremos conectar você as pessoas certas.
+
+## Onde e quando serão publicado os resultados?
+
+Esperamos publicar os resultados sumarizados dentro de um ou dois meses depois que a pesquisa estiver completa. Os resultados serão publicados no [blog oficial do projeto](https://blog.rust-lang.org).
+
+## Onde eu posso ver os resultados anteriores?
+
+* [State of Rust 2016](https://blog.rust-lang.org/2016/06/30/State-of-Rust-Survey-2016.html)


### PR DESCRIPTION
There is a growing community in Brasil interested in Rust, and we would like to have their participation on the `State of Rust Survey`, allowing them to express on the language they feel most comfortable to participate.

This effort means we would be able to translate the `Survey` to Portuguese, giving the chance to have inputs of members of the community that feel more comfortable to write on their native tongue.
To make they welcome, it would be nice to have a translation of the FAQ, not only of the survey, to give provide details on how the data collected on the survey will be used.

This commit is the initial translation of the [English FAQ](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ) on the Wiki. This document was put on the main repo to allow contributions in the form of Pull Requests.
The initial idea is to have the same file name under the `docs/pt-br` folder, to accommodate more translations if there is interest.

[Rendered](https://github.com/bltavares/team/blob/patch-1/docs/pt-br/State-of-the-Rust-Language-Community-Survey-FAQ.md)